### PR TITLE
Rename special page classes to match convention

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -71,8 +71,8 @@
 		]
 	},
 	"SpecialPages": {
-		"Bucket": "MediaWiki\\Extension\\Bucket\\BucketSpecial",
-		"AllBuckets": "MediaWiki\\Extension\\Bucket\\AllBucketsSpecial"
+		"Bucket": "MediaWiki\\Extension\\Bucket\\SpecialBucket",
+		"AllBuckets": "MediaWiki\\Extension\\Bucket\\SpecialAllBuckets"
 	},
 	"ResourceFileModulePaths": {
 		"localBasePath": "",

--- a/includes/SpecialAllBuckets.php
+++ b/includes/SpecialAllBuckets.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\Bucket;
 
 use MediaWiki\SpecialPage\SpecialPage;
 
-class AllBucketsSpecial extends SpecialPage {
+class SpecialAllBuckets extends SpecialPage {
 	public function __construct() {
 		parent::__construct( 'AllBuckets' );
 	}

--- a/includes/SpecialBucket.php
+++ b/includes/SpecialBucket.php
@@ -5,7 +5,7 @@ namespace MediaWiki\Extension\Bucket;
 use MediaWiki\SpecialPage\SpecialPage;
 use OOUI;
 
-class BucketSpecial extends SpecialPage {
+class SpecialBucket extends SpecialPage {
 	public function __construct() {
 		parent::__construct( 'Bucket' );
 	}


### PR DESCRIPTION
In MediaWiki core and almost anywhere else, special pages always start with `Special`. This PR renames the two special page classes to match this convention.