### PR TITLE
Properly display an empty bucket

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -16,6 +16,8 @@
     "bucket-next-results": "Next $1 results",
     "specialpages-group-bucket": "Bucket",
     "bucket-specialpage-search": "Bucket Search",
+	"bucket-empty": "This Bucket does not contain any entry.",
+	"bucket-empty-query": "The query does not match any entry in the Bucket.",
 
     "allbuckets-heading": "Bucket",
 

--- a/includes/BucketAction.php
+++ b/includes/BucketAction.php
@@ -39,7 +39,7 @@ class BucketAction extends Action {
 		}
 
 		if ( count( $buckets ) === 0 ) {
-			$out->addHTML( Html::noticeBox( $out->msg( 'bucket-action-writes-empty' )->parse(), '' ) );
+			$out->addHTML( Html::noticeBox( $out->msg( 'bucket-action-writes-empty' )->parse(), 'bucket-action-writes-empty' ) );
 			return;
 		}
 

--- a/includes/BucketPage.php
+++ b/includes/BucketPage.php
@@ -3,6 +3,7 @@
 namespace MediaWiki\Extension\Bucket;
 
 use Article;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
 use Mediawiki\Title\Title;
 use MediaWiki\Title\TitleValue;
@@ -18,7 +19,10 @@ class BucketPage extends Article {
 		$context = $this->getContext();
 		$out = $this->getContext()->getOutput();
 		$out->enableOOUI();
-		$out->addModuleStyles( 'ext.bucket.bucketpage.css' );
+		$out->addModuleStyles( [
+			'ext.bucket.page.css',
+			'mediawiki.codex.messagebox.styles'
+		] );
 		$title = $this->getTitle();
 		$out->setPageTitle( $title );
 
@@ -78,6 +82,10 @@ class BucketPage extends Article {
 		$out->addHTML( ' ' );
 		$out->addHTML( $linkRenderer->makeKnownLink( new TitleValue( NS_SPECIAL, 'Bucket' ), wfMessage( 'bucket-page-dive-into' ), [], $specialQueryValues ) );
 		$out->addHTML( '<br>' );
+
+		if ( $maxCount === '0' ) {
+			return $out->addHTML( Html::noticeBox( $out->msg( 'bucket-empty' )->parse(), 'bucket-empty' ) );
+		}
 
 		$pageLinks = BucketPageHelper::getPageLinks( $title, $limit, $offset, $context->getRequest()->getQueryValues(), ( $resultCount === $limit ) );
 

--- a/includes/BucketSpecial.php
+++ b/includes/BucketSpecial.php
@@ -2,6 +2,7 @@
 
 namespace MediaWiki\Extension\Bucket;
 
+use MediaWiki\Html\Html;
 use MediaWiki\SpecialPage\SpecialPage;
 use OOUI;
 
@@ -114,6 +115,9 @@ class BucketSpecial extends SpecialPage {
 		$this->setHeaders();
 		$out->enableOOUI();
 		$out->setPageTitle( 'Bucket browse' );
+		$out->addModuleStyles( [
+			'mediawiki.codex.messagebox.styles'
+		] );
 
 		$bucket = $request->getText( 'bucket', '' );
 		$select = $request->getText( 'select', '*' );
@@ -153,6 +157,11 @@ class BucketSpecial extends SpecialPage {
 
 		$resultCount = count( $fullResult['bucket'] );
 		$endResult = $offset + $resultCount;
+
+		if ( $resultCount === 0 ) {
+			return $out->addHTML( Html::noticeBox( $out->msg( 'bucket-empty-query' )->parse(), 'bucket-empty-query' ) );
+		}
+
 		$out->addHTML( wfMessage( 'bucket-page-result-counter', $resultCount, $offset, $endResult ) . '<br>' );
 
 		$pageLinks = BucketPageHelper::getPageLinks( $this->getFullTitle(), $limit, $offset, $request->getQueryValues(), ( $resultCount === $limit ) );


### PR DESCRIPTION
Instead of returning a paginator that does not really work and an empty table with only headings, explicitly show that the bucket is empty/the query didn't return anything.