### PR TITLE
MediaWiki 1.44 compatibility

### DIFF
--- a/includes/BucketWriter.php
+++ b/includes/BucketWriter.php
@@ -108,7 +108,7 @@ class BucketWriter {
 			$tablePuts = [];
 			$dbTableName = BucketDatabase::getBucketTableName( $bucketName );
 			$res = $dbw->newSelectQueryBuilder()
-				->from( $dbw->addIdentifierQuotes( $dbTableName ) )
+				->from( $dbTableName )
 				->select( '*' )
 				->forUpdate()
 				->where( [ '_page_id' => $pageId ] )


### PR DESCRIPTION
The only change required for MediaWiki 1.44 compatibility is the removal of one `$dbw->addIdentifierQuotes()` call. We've been running Bucket with this patch for a few days on UT/DR, and there is also [some interest for the extension on Miraheze](https://issue-tracker.miraheze.org/T14235). With the mentioned call, MediaWiki throws an error like this:

```
[exception] [d173874c115bc1d9fd238250] /index.php?title=Create&action=submit   Wikimedia\Rdbms\DBLanguageError: Identifier must not contain quote, dot or null characters: got '`bucket__bucket_issues`'
#0 /var/www/html/includes/libs/rdbms/platform/SQLPlatform.php(1033): Wikimedia\Rdbms\Platform\SQLPlatform->addIdentifierQuotes(string)
#1 /var/www/html/includes/libs/rdbms/platform/SQLPlatform.php(913): Wikimedia\Rdbms\Platform\SQLPlatform->tableNameWithAlias(string, string)
#2 /var/www/html/includes/libs/rdbms/platform/SQLPlatform.php(701): Wikimedia\Rdbms\Platform\SQLPlatform->tableNamesWithIndexClauseOrJOIN(array, array, array, array)
#3 /var/www/html/includes/libs/rdbms/database/Database.php(3323): Wikimedia\Rdbms\Platform\SQLPlatform->selectSQLText(array, array, array, string, array, array)
#4 /var/www/html/includes/libs/rdbms/database/DatabaseMySQL.php(641): Wikimedia\Rdbms\Database->selectSQLText(array, array, array, string, array, array)
#5 /var/www/html/includes/libs/rdbms/database/Database.php(1359): Wikimedia\Rdbms\DatabaseMySQL->selectSQLText(array, array, array, string, array, array)
#6 /var/www/html/includes/libs/rdbms/querybuilder/SelectQueryBuilder.php(761): Wikimedia\Rdbms\Database->select(array, array, array, string, array, array)
#7 /var/www/html/extensions/Bucket/includes/BucketWriter.php(116): Wikimedia\Rdbms\SelectQueryBuilder->fetchResultSet()
#8 /var/www/html/extensions/Bucket/includes/BucketWriter.php(214): MediaWiki\Extension\Bucket\BucketWriter->writePuts(int, string, array, bool)
#9 /var/www/html/extensions/Bucket/includes/Bucket.php(43): MediaWiki\Extension\Bucket\BucketWriter->writePuts(int, string, array)
#10 /var/www/html/extensions/Bucket/includes/Hooks/Handlers/GeneralHandler.php(88): MediaWiki\Extension\Bucket\Bucket::writePuts(int, string, array)
#11 /var/www/html/includes/HookContainer/HookContainer.php(155): MediaWiki\Extension\Bucket\Hooks\Handlers\GeneralHandler->onLinksUpdateComplete(MediaWiki\Deferred\LinksUpdate\LinksUpdate, int)
```

As far as I can see, MediaWiki 1.43 also takes the code path through `tableNamesWithIndexClauseOrJOIN`, which should already call `addIdentifierQuotes` on the input, so I assume the change should be safe. I'm not particularly sure why MediaWiki 1.44 throws an error on it, though.