### PR TITLE
Fix join order

### DIFF
--- a/includes/BucketQuery.php
+++ b/includes/BucketQuery.php
@@ -87,9 +87,9 @@ class BucketQuery {
 		if ( !isset( self::$schemaCache[$data['bucketName']] ) ) {
 			$neededSchemas[] = $data['bucketName'];
 		}
-		foreach ( $data['joins'] as $join ) {
-			if ( !isset( self::$schemaCache[$join['bucketName']] ) ) {
-				$neededSchemas[] = $join['bucketName'];
+		foreach ( $data['joinOrder'] as $joinTable ) {
+			if ( !isset( self::$schemaCache[$joinTable] ) ) {
+				$neededSchemas[] = $joinTable;
 			}
 		}
 		// Populate the schema cache with missing schemas
@@ -122,18 +122,17 @@ class BucketQuery {
 		$this->orderByFields[] = new FieldSelector( '_page_id', $this );
 		$this->orderByFields[] = new FieldSelector( '_index', $this );
 
-		foreach ( $data['joins'] as $join ) {
-			if ( !is_array( $join['cond'] ) || count( $join['cond'] ) !== 2 ) {
-				throw new QueryException( wfMessage( 'bucket-query-invalid-join', json_encode( $join ) ) );
-			}
-			$joinTable = $join['bucketName'];
-			$field1 = $join['cond'][0];
-			$field2 = $join['cond'][1];
-			$schema = self::$schemaCache[$join['bucketName']];
-
+		foreach ( $data['joinOrder'] as $joinTable ) {
 			if ( isset( $this->joins[$joinTable] ) ) {
 				throw new QueryException( wfMessage( 'bucket-query-duplicate-join', $joinTable ) );
 			}
+			$join = $data['joins'][$joinTable];
+			if ( !is_array( $join ) || !is_array( $join['cond'] ) || count( $join['cond'] ) !== 2 ) {
+				throw new QueryException( wfMessage( 'bucket-query-invalid-join', json_encode( $join ) ) );
+			}
+			$field1 = $join['cond'][0];
+			$field2 = $join['cond'][1];
+			$schema = self::$schemaCache[$joinTable];
 
 			$joinTableSchema = new BucketSchema( $joinTable, $schema );
 			$this->schemas[$joinTableSchema->getName()] = $joinTableSchema;

--- a/includes/BucketQuery.php
+++ b/includes/BucketQuery.php
@@ -255,7 +255,7 @@ class BucketQuery {
 			if ( $join instanceof CategoryJoin ) {
 				$builder->leftJoin( 'categorylinks', $join->getAlias(), $join->getSQL( $dbw ) );
 			} else {
-				$builder->leftJoin( $join->getAlias( $dbw ), $join->getAlias( $dbw ), $join->getSQL( $dbw ) );
+				$builder->leftJoin( $join->getAlias(), $join->getAlias(), $join->getSQL( $dbw ) );
 			}
 		}
 

--- a/includes/LuaLibrary.php
+++ b/includes/LuaLibrary.php
@@ -74,8 +74,8 @@ class LuaLibrary extends LibraryBase {
 		}
 		try {
 			$this->linkToBucket( $data['bucketName'] );
-			foreach ( $data['joins'] as $join ) {
-				$this->linkToBucket( $join['bucketName'] );
+			foreach ( $data['joinOrder'] as $joinTable ) {
+				$this->linkToBucket( $joinTable );
 			}
 			$data = self::convertFromLuaTable( $data );
 			$rows = Bucket::runSelect( $data );

--- a/includes/mw.ext.bucket.lua
+++ b/includes/mw.ext.bucket.lua
@@ -72,6 +72,7 @@ function QueryBuilder:new(bucketName)
         selects = {},
         wheres = {op = "AND", operands = {}},
         joins = {},
+        joinOrder = {},
         orderBy = nil,
         subversion = "",
         limit_arg = nil,
@@ -217,6 +218,7 @@ function QueryBuilder:join(bucketName, fieldOne, fieldTwo)
     end
 
     self.joins[bucketName] = {bucketName = bucketName, cond = {fieldOne, fieldTwo}}
+    table.insert(self.joinOrder, bucketName)
     return self
 end
 


### PR DESCRIPTION
All information about joins is stored in the `joins` Lua table in the query builder. Lua table keys are not guaranteed to be traversed in insertion order, which makes the query builder accidentally reorder joined tables.

For the following query on [Undertale Wiki's Soundtrack module](https://undertale.wiki/w/Module:Soundtrack) (I have since changed the module to not require three joins, but this was the query that was causing problems):

```lua
bucket('album')
	.join('track_album', 'album.page_name', 'track_album.album')
	.join('track', 'track_album.page_name', 'track.page_name')
	.join('track_motif', 'track.page_name', 'track_motif.track')
	.select(
		'album.bandcamp',
		'track_album.number',
		'track.title',
		'track.time',
		'track.location',
		'track.bandcamp',
		'track.youtube',
		'track_motif.motif',
		'track_motif.major'
	)
	.orderBy('track_album.number')
	.where('album.page_name', 'Undertale Demo OST')
	.run()
```

I received the error: "Bucket track_album not found in query." This is how the query was represented in Lua:

```lua
table#1 {
    metatable = table#2
    ["bucketName"] = "album",
    ["debug"] = false,
    ["joins"] = table#4 {
        ["track"] = table#5 {
            ["bucketName"] = "track",
            ["cond"] = table#6 {
                "track_album.page_name",
                "track.page_name",
            },
        },
        ["track_album"] = table#7 {
            ["bucketName"] = "track_album",
            ["cond"] = table#8 {
                "album.page_name",
                "track_album.album",
            },
        },
        ["track_motif"] = table#9 {
            ["bucketName"] = "track_motif",
            ["cond"] = table#10 {
                "track.page_name",
                "track_motif.track",
            },
        },
    },
    ["orderBy"] = table#11 {
        ["direction"] = "ASC",
        ["fieldName"] = "track_album.number",
    },
    ["selects"] = table#12 {
        "album.bandcamp",
        "track_album.number",
        "track.title",
        "track.time",
        "track.location",
        "track.bandcamp",
        "track.youtube",
        "track_motif.motif",
        "track_motif.major",
    },
    ["subversion"] = "",
    ["wheres"] = table#13 {
        ["op"] = "AND",
        ["operands"] = table#14 {
            table#15 {
                "album.page_name",
                "=",
                "Undertale Demo OST",
            },
        },
    },
}
```

You can see that the table `track` appeared before `track_album`, making Bucket attempt a join with `track` before attempting a join with `track_album`, throwing the error when it notices that the `track_album` table has not already been joined with.

This pull request fixes the issue by introducing a new `joinOrder` Lua table with the specific order in which tables are joined, and using it on the PHP side to traverse the joins in the order they were intended. It also removes the `$dbw` parameter from a few `Join::getAlias()` calls, because said method accepts no parameters.

This fix has been deployed on Undertale Wiki and Deltarune Wiki, and so far I haven't noticed issues (both with the previously faulty query that I gave here as an example and any other query we have on the wiki).