### PR TITLE
Bucket.i18n.alias.php: Minor changes

### DIFF
--- a/Bucket.i18n.alias.php
+++ b/Bucket.i18n.alias.php
@@ -7,13 +7,13 @@
 
 $specialPageAliases = [];
 
-/** German (Deutsch) */
+/** English (English) */
 $specialPageAliases['en'] = [
 	'Bucket' => [ 'Bucket' ],
 ];
 
-/** English (English) */
-$specialPageAliases['en'] = [
+/** German (Deutsch) */
+$specialPageAliases['de'] = [
 	'Bucket' => [ 'Bucket' ],
 ];
 


### PR DESCRIPTION
What:
* Move "en" to the first one, in conventions of other extensions
* Fix wrong langcode for the German language