### PR TITLE
Handle invalid category titles gracefully

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -90,6 +90,7 @@
 	"bucket-query-must-be-type-type-nil": "nil",
 	"bucket-query-null-invalid-operator": "Only '=' and '!=' are valid comparisons for bucket.Null(). Found $1",
 	"bucket-query-expected-category": "Expected category, found $1",
+	"bucket-query-invalid-category-name": "Invalid category name: $1",
 	"bucket-query-total-time-expired": "Page has exceeded total time allocated for running bucket queries",
 	"bucket-limitreport-run-time": "Bucket time usage",
 	"bucket-limitreport-run-time-value": "$1/$2 seconds",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -87,6 +87,7 @@
 	"bucket-query-must-be-type-type-nil": "{{Optional|The name of nil type}}",
 	"bucket-query-null-invalid-operator": "Message on unsupported comparsions for bucket.Null(). $1 for the specified comparsion",
 	"bucket-query-expected-category": "Message on category expected but not. $1 for the specified name",
+	"bucket-query-invalid-category-name": "Message when an invalid category page name was given for a query",
 	"bucket-query-total-time-expired": "Message on page has exceeded total time allocated for running bucket queries",
 	"bucket-limitreport-run-time": "Title of bucket time usages",
 	"bucket-limitreport-run-time-value": "Time usages. $1 for used time, $2 for allocated time",

--- a/includes/BucketQuery.php
+++ b/includes/BucketQuery.php
@@ -209,6 +209,11 @@ class BucketQuery {
 
 	private function addCategoryJoin( string $category ) {
 		if ( !isset( $this->categories[$category] ) ) {
+			$categoryTitle = Title::newFromText( $category, NS_CATEGORY );
+			if ( !$categoryTitle ) {
+				throw new QueryException( wfMessage( 'bucket-query-invalid-category-name', $category ) );
+			}
+
 			$categoryAlias = 'category' . $this->categoryCount++;
 			$this->categories[$category] = $categoryAlias;
 			if ( $this->useLinkTarget ) {


### PR DESCRIPTION
Resolves an unhandled exception (occurring both in a page view context and an API query context) if a user-provided category name contains illegal title characters.