### PR TITLE
Replace usage of deprecated Scribunto::getParserEngine function

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -71,7 +71,13 @@
 		"bucket": "MediaWiki\\Extension\\Bucket\\BucketAction"
 	},
 	"APIModules": {
-		"bucket": "MediaWiki\\Extension\\Bucket\\BucketApi"
+		"bucket": {
+			"class": "MediaWiki\\Extension\\Bucket\\BucketApi",
+			"services": [
+				"Scribunto.EngineFactory",
+				"ParserFactory"
+			]
+		}
 	},
 	"MessagesDirs": {
 		"Bucket": [

--- a/includes/BucketApi.php
+++ b/includes/BucketApi.php
@@ -3,14 +3,24 @@
 namespace MediaWiki\Extension\Bucket;
 
 use MediaWiki\Api\ApiBase;
-use MediaWiki\Extension\Scribunto\Scribunto;
+use MediaWiki\Api\ApiMain;
+use MediaWiki\Extension\Scribunto\EngineFactory;
 use MediaWiki\Extension\Scribunto\ScribuntoException;
-use MediaWiki\MediaWikiServices;
 use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\ParserFactory;
 use MediaWiki\Parser\ParserOptions;
 use Wikimedia\ParamValidator\ParamValidator;
 
 class BucketApi extends ApiBase {
+
+	public function __construct(
+		ApiMain $mainModule,
+		string $moduleName,
+		private readonly EngineFactory $engineFactory,
+		private readonly ParserFactory $parserFactory,
+	) {
+		parent::__construct( $mainModule, $moduleName );
+	}
 
 	public function execute() {
 		$this->getMain()->setCacheMode( 'public' );
@@ -31,10 +41,10 @@ class BucketApi extends ApiBase {
 			return;
 		}
 
-		$parser = MediaWikiServices::getInstance()->getParser();
+		$parser = $this->parserFactory->create();
 		$options = new ParserOptions( $this->getUser() );
 		$parser->startExternalParse( $title, $options, Parser::OT_HTML, true );
-		$engine = Scribunto::getParserEngine( $parser );
+		$engine = $this->engineFactory->getEngineForParser( $parser );
 		try {
 			$result = $engine->runConsole( [
 				'title' => $title,


### PR DESCRIPTION
Deprecated since 1.45, starts emitting deprecation warnings in 1.46.

Also inject the EngineFactory and the ParserFactory into the API class.