### PR TITLE
Remove unneeded vararg from standardizeWhere

### DIFF
--- a/includes/mw.ext.bucket.lua
+++ b/includes/mw.ext.bucket.lua
@@ -105,12 +105,10 @@ end
 -- This function takes any accepted condition, and outputs a condition formatted as {field, operator, value}
 -- .where{{"a", ">", 0}, {"b", "=", "5"}})
 -- .where("Category:Foo")
--- .where(a = 1, b = 2)
+-- .where({a = 1, b = 2})
 -- .where("id", 100)
 -- .where("id", ">", 100)
-local function standardizeWhere(...)
-    local val = ...
-
+local function standardizeWhere(val)
     if hasOp(val) then
         if val['operands'] ~= nil then
             local children = {}


### PR DESCRIPTION
`local val = ...` sets `val` to the first argument and discards the rest. `standardizeWhere` is also only called with a single argument.