### PR TITLE
Fix fatal TypeError when saving a Bucket-namespace page

### DIFF
--- a/includes/Hooks/Handlers/GeneralHandler.php
+++ b/includes/Hooks/Handlers/GeneralHandler.php
@@ -147,6 +147,8 @@ class GeneralHandler implements
 			$status->fatal( $e->getwfMessage() );
 			return false;
 		}
+
+		return true;
 	}
 
 	/** @inheritDoc */

--- a/includes/Hooks/Handlers/GeneralHandler.php
+++ b/includes/Hooks/Handlers/GeneralHandler.php
@@ -143,12 +143,11 @@ class GeneralHandler implements
 		$isExistingPage = $revRecord->getParentId() !== null;
 		try {
 			BucketDatabase::createOrModifyTable( $title, $jsonSchema, $isExistingPage );
+			return true;
 		} catch ( BucketException $e ) {
 			$status->fatal( $e->getwfMessage() );
 			return false;
 		}
-
-		return true;
 	}
 
 	/** @inheritDoc */


### PR DESCRIPTION
## Problem

`GeneralHandler::onMultiContentSave()` declares a `: bool` return type, but the success path — reached whenever `createOrModifyTable()` completes without throwing — falls through the end of the method without returning. Under PHP 8 this returns `null` and throws a fatal:

```
TypeError: MediaWiki\Extension\Bucket\Hooks\Handlers\GeneralHandler::onMultiContentSave(): Return value must be of type bool, none returned
```

Since this hook fires on every save, **no page in the Bucket namespace can be saved** — saving a bucket schema page aborts with the fatal above. (Note the per-bucket table/grant created via `onTransactionCommitOrIdle` may have already been committed as DDL before the fatal aborts the save, which can leave orphaned tables.)

The method's other branches already return explicitly (`return true` for non-Bucket-namespace pages on line 134, `return false` in the `catch`); only the happy path was missing one.

## Fix

Add the missing `return true;` after the `try/catch`, so a successful schema update lets the save proceed.

`MultiContentSaveHook` documents `@return bool|void` ("True or no return value to continue"), so the value is correct; the fatal stems purely from this handler's explicit `: bool` declaration combined with the missing return.

## Reproduction

1. Install Bucket and run `update.php`.
2. Create a page in the `Bucket:` namespace with a valid JSON schema, e.g. `{"label":{"type":"TEXT","index":true}}`.
3. Without this patch: save fails with the `TypeError` above. With it: the page saves and the `bucket__<name>` table is created.

Verified on MediaWiki 1.46 / PHP 8.3.