### PR TITLE
Document that the wiki DB user needs GRANT OPTION for Bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,12 @@ Bucket is still under active development, and the API and schema are unstable an
 ```sql
 CREATE USER 'bucket'@'<SERVER_HOSTNAME>' IDENTIFIED BY '<PASSWORD>';
 ```
-4. Ensure the configuration variables are set correctly (see table below)
-5. Run `php maintenance/run.php Bucket:SetupDBPermission` to setup required database permissions
+4. Grant the wiki's own database user (`$wgDBuser`) the `GRANT OPTION` on the wiki database, so Bucket can delegate access to the Bucket user, e.g
+```sql
+GRANT ALL PRIVILEGES ON `<WIKI_DATABASE>`.* TO '<WIKI_DB_USER>'@'<SERVER_HOSTNAME>' WITH GRANT OPTION;
+```
+5. Ensure the configuration variables are set correctly (see table below)
+6. Run `php maintenance/run.php Bucket:SetupDBPermission` to setup required database permissions
 
 ## Configuration
  | Variable | Description | Default


### PR DESCRIPTION
## Background

Bucket grants the dedicated Bucket user access to each bucket's table using the **wiki's own** database connection (`$wgDBuser`), not the Bucket user's connection:

- `Bucket:SetupDBPermission` issues its `GRANT`s over the main connection.
- At runtime, `BucketDatabase::createOrModifyTable()` runs `GRANT ALL ON bucket__<name> TO <bucketuser>` over the main connection every time a bucket is created.

For either to work, `$wgDBuser` must be able to `GRANT` privileges on the wiki database (i.e. hold the relevant privileges **with `GRANT OPTION`**).

## Why this matters

A database account created by the **standard MediaWiki installer** is granted only `SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES` (`MysqlInstaller::$webUserPrivs`) and has no `GRANT OPTION`. With such an account:

- `Bucket:SetupDBPermission` aborts with *"the database user … needs permission to … GRANT privileges to another database user"* (the script already detects this case).
- Saving a `Bucket:` page later fails when `createOrModifyTable()` tries to grant the Bucket user access to the new table.

The error message in `SetupDBPermission` hints at the requirement, but it isn't stated in the install instructions, so a by-the-book MediaWiki setup hits it.

## Change

Adds the `GRANT OPTION` requirement to the install instructions as a new **step 4** (after creating the Bucket user, before configuration and `Bucket:SetupDBPermission`), with an example `GRANT` statement; the following steps are renumbered to 5 and 6.

Docs only — no code change. Wording is open to revision to match project conventions.