### PR TITLE
Run CI on MW 1.46 + PHP 8.3 as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
           - mw: 'REL1_45'
             php: 8.2
             experimental: false
+          - mw: 'REL1_46'
+            php: 8.3
+            experimental: false
 
     steps:
       - name: Setup PHP


### PR DESCRIPTION
1.46 has a release candidate now, and we should make sure that the extension is compatible with it.