### PR TITLE
Apply the table prefix to repeated-field sub-tables

### DIFF
--- a/includes/BucketDatabase.php
+++ b/includes/BucketDatabase.php
@@ -321,7 +321,8 @@ class BucketDatabase {
 
 		// Create a key to match the main table primary key
 		$createTableFragments[] = 'INDEX idx_page_index (_page_id, _index)';
-		$dbTableName = self::getSubTableName( $newSchema->getName(), $originalField->getFieldName() );
+		$dbTableName = $dbw->tableName(
+			self::getSubTableName( $newSchema->getName(), $originalField->getFieldName() ) );
 		return [
 			'permissionName' => $dbTableName,
 			'statement' =>


### PR DESCRIPTION
Follow-up to #23. One `$wgDBprefix` site is still unfixed.

## The bug

`getCreateRepeatedTableStatement()` builds its table name from `getSubTableName()` raw, and uses it both as `permissionName` and inside the `CREATE TABLE`. `createOrModifyTable()` re-wraps `permissionName` in `tableName()` at `:149`, so the `GRANT` names `<prefix>bucket__x__y` while the `CREATE` names `bucket__x__y`. With no prefix the two spellings coincide, which is presumably why it has gone unnoticed.

The `DROP` sites for the same sub-tables at `:221` and `:257` were wrapped in 6447693. That asymmetry is what makes the failure permanent rather than merely wrong: a prefixed `DROP` no-ops against the unprefixed orphan, so the re-`CREATE` fails from then on.

## Reproduced on MariaDB 12.3.3, prefix `wiki`

| Bucket account | Result |
|---|---|
| least privilege (the `SetupDBPermission` grant set) | `ERROR 1142: CREATE command denied ... bucket__t__tags` — the schema page cannot save, nothing is written |
| broader privileges | `CREATE` succeeds unprefixed → reads and writes get `ERROR 1146` → a type change on the field gives a permanent `ERROR 1050` |

The second case is the worse one: the `1050` is raised inside `onMultiContentSave()`, which catches only `BucketException`, so the page fails to save on every retry with no way to recover from the wiki UI.

## The fix

Passing the name through `tableName()` makes this path match the main table's at `:290`. Because `tableName()` leaves an already-qualified name alone, `permissionName` stays correct when `:149` re-wraps it — so one call fixes both the `CREATE` and the `GRANT`.

Verified afterwards: `GRANT`, `CREATE`, `INSERT` and `DELETE` all agree on `wikibucket__t__tags`, and the least-privilege account can perform all four.

Wrapped rather than kept on one line because the single-line form is 121 characters with tabs at 4, one over `Generic.Files.LineLength`; the wrapped form matches the style at `:219-220` and `:256-257`.

This is running in production on a prefixed wiki.