### PR TITLE
Put editbucket in a grant so OAuth and bot clients can use it

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -150,6 +150,11 @@
 			"editbucket": true
 		}
 	},
+	"GrantPermissions": {
+		"editpage": {
+			"editbucket": true
+		}
+	},
 	"ConfigRegistry": {
 		"bucket": "GlobalVarConfig::newInstance"
 	},


### PR DESCRIPTION
## The gap

`editbucket` is declared in `AvailableRights` and assigned to `sysop`, but appears in no `$wgGrantPermissions` entry — so no OAuth client or bot password can edit a Bucket page on any wiki.

## Decisions

- **Tie `editbucket` to `editpage` rather than define a new grant.** The right is inert without `edit` — all it does is unlock editing in NS_BUCKET — so a dedicated `bucket` grant would be a scope nobody could ever authorise on its own. Core places its own namespace-unlock rights, such as `editprotected`, in `editpage` for the same reason.
- **`editpage` is where someone authorising an app would expect it.** Having granted an app page-editing access, that it can edit pages in a protected namespace the user can already edit themselves is the unsurprising outcome.
- **This does not widen who can edit Bucket pages.** Grants filter rights, they do not confer them. A consumer can edit a Bucket page only if the user already holds `editbucket` **and** the consumer holds `editpage`.